### PR TITLE
Index all boxes + add notes/byPubkey endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "chaincash_predicate",
  "chaincash_services",
  "chaincash_store",
+ "ergo-lib",
  "ergo_client",
  "hyper 0.14.30",
  "serde",

--- a/crates/chaincash_server/Cargo.toml
+++ b/crates/chaincash_server/Cargo.toml
@@ -15,6 +15,7 @@ hyper = { version = "0.14.27", features = ["full"] }
 tracing = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
+ergo-lib = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ergo_client = { workspace = true }

--- a/crates/chaincash_server/src/reserves.rs
+++ b/crates/chaincash_server/src/reserves.rs
@@ -41,13 +41,19 @@ async fn top_up_reserve(
     Ok(response.into_response())
 }
 
-async fn list_reserves(State(state): State<Arc<ServerState>>) -> Result<Response, ApiError> {
-    Ok(Json(state.store.reserves().reserve_boxes()?).into_response())
+async fn list_wallet_reserves(State(state): State<Arc<ServerState>>) -> Result<Response, ApiError> {
+    Ok(Json(
+        state
+            .store
+            .reserves()
+            .reserve_boxes_by_pubkeys(&state.wallet_pubkeys().await?)?,
+    )
+    .into_response())
 }
 
 pub fn router() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/mint", post(mint_reserve))
         .route("/topup", post(top_up_reserve))
-        .route("/", get(list_reserves))
+        .route("/wallet", get(list_wallet_reserves))
 }

--- a/crates/chaincash_services/src/lib.rs
+++ b/crates/chaincash_services/src/lib.rs
@@ -2,7 +2,8 @@ use chaincash_predicate::predicates::Predicate;
 use chaincash_store::ChainCashStore;
 use compiler::Compiler;
 use ergo_client::node::NodeClient;
-use transaction::TransactionService;
+use ergo_lib::{ergo_chain_types::EcPoint, ergotree_ir::chain::address::Address};
+use transaction::{TransactionService, TransactionServiceError};
 
 pub mod compiler;
 pub mod scanner;
@@ -25,6 +26,22 @@ impl ServerState {
             predicates,
         }
     }
+
+    pub async fn wallet_pubkeys(&self) -> Result<Vec<EcPoint>, TransactionServiceError> {
+        Ok(self
+            .node
+            .endpoints()
+            .wallet()?
+            .get_addresses()
+            .await?
+            .into_iter()
+            .filter_map(|addr| match addr.address() {
+                Address::P2Pk(provedlog) => Some(*provedlog.h),
+                _ => None,
+            })
+            .collect())
+    }
+
     pub fn tx_service(&self) -> TransactionService {
         TransactionService::new(&self.node, &self.store, &self.compiler)
     }

--- a/crates/chaincash_store/migrations/2024-08-28-071415_create_pubkey_indices/down.sql
+++ b/crates/chaincash_store/migrations/2024-08-28-071415_create_pubkey_indices/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX reserve_pubkey_idx;
+DROP INDEX note_pubkey_idx;

--- a/crates/chaincash_store/migrations/2024-08-28-071415_create_pubkey_indices/up.sql
+++ b/crates/chaincash_store/migrations/2024-08-28-071415_create_pubkey_indices/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX reserve_pubkey_idx ON reserves(owner);
+CREATE INDEX note_pubkey_idx ON notes(owner);

--- a/crates/chaincash_store/src/notes.rs
+++ b/crates/chaincash_store/src/notes.rs
@@ -9,7 +9,10 @@ use diesel::{
     BelongingToDsl, Connection, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl,
     Selectable, SelectableHelper,
 };
-use ergo_lib::ergotree_ir::chain::{self, ergo_box::BoxId, token::TokenId};
+use ergo_lib::{
+    ergo_chain_types::EcPoint,
+    ergotree_ir::chain::{self, ergo_box::BoxId, token::TokenId},
+};
 use serde::Serialize;
 
 use crate::{
@@ -170,9 +173,10 @@ impl NoteRepository {
             .transpose()
     }
 
-    pub fn notes(&self) -> Result<Vec<NoteWithHistory>, Error> {
+    pub fn notes_by_pubkeys(&self, pubkeys: &[EcPoint]) -> Result<Vec<NoteWithHistory>, Error> {
         let mut conn = self.pool.get()?;
         let notes = schema::notes::table
+            .filter(schema::notes::owner.eq_any(pubkeys.into_iter().cloned().map(String::from)))
             .select(Note::as_select())
             .load(conn.borrow_mut())?;
         Ok(OwnershipEntry::belonging_to(&notes)

--- a/crates/chaincash_store/src/reserves.rs
+++ b/crates/chaincash_store/src/reserves.rs
@@ -6,6 +6,7 @@ use crate::Error;
 use chaincash_offchain::boxes::ReserveBoxSpec;
 use diesel::dsl::delete;
 use diesel::prelude::*;
+use ergo_lib::ergo_chain_types::EcPoint;
 use ergo_lib::ergotree_ir::chain;
 use ergo_lib::ergotree_ir::chain::ergo_box::BoxId;
 use ergo_lib::ergotree_ir::chain::token::TokenId;
@@ -82,10 +83,14 @@ impl ReserveRepository {
         .expect("Failed to parse ReserveBoxSpec from database"))
     }
 
-    pub fn reserve_boxes(&self) -> Result<Vec<ReserveBoxSpec>, Error> {
+    pub fn reserve_boxes_by_pubkeys(
+        &self,
+        pubkeys: &[EcPoint],
+    ) -> Result<Vec<ReserveBoxSpec>, Error> {
         let mut conn = self.pool.get()?;
         let join = schema::reserves::table
             .inner_join(schema::ergo_boxes::table)
+            .filter(schema::reserves::owner.eq_any(pubkeys.into_iter().cloned().map(String::from)))
             .select((Reserve::as_select(), ErgoBox::as_select()))
             .load::<(Reserve, ErgoBox)>(&mut conn)?;
         // Panic here if parsing ReserveBox from database fails


### PR DESCRIPTION
Index all chaincash-rs boxes (notes, receipts). 

Moved /notes/ and /reserves/ endpoints (to list all notes/reserves belonging to user) to /notes/wallet and /reserves/wallet. Also added a /notes/byPubkey endpoint