### PR TITLE
Fix checkNote acceptance API for chaincash server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ With the `ChainCash` server running locally we can perform an API request to get
 curl http://localhost:8080/api/v1/acceptance
 ```
 
+To check whether a JSON encoded note can be accepted by the configured predicates, post it to the check endpoint:
+
+```sh
+curl -X POST http://localhost:8080/api/v1/acceptance/checkNote \
+  -H "content-type: application/json" \
+  -d '{"nanoerg":1000,"owner":"owner1","issuer":"issuer1","signers":["issuer1"]}'
+```
+
+The response contains a boolean `accepted` field.
+
 ### Predicate Types
 
 Currently the following predicates are supported:

--- a/crates/chaincash_predicate/src/context.rs
+++ b/crates/chaincash_predicate/src/context.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 pub type NanoErg = u64;
 pub type PubKeyHex = String;
 
 /// Context related to a note that holds information required by predicates
 /// to determine if the note is acceptable.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NoteContext {
     /// The nanoerg value of the related note
     /// The denomination of the note converted to its erg value

--- a/crates/chaincash_server/src/acceptance.rs
+++ b/crates/chaincash_server/src/acceptance.rs
@@ -1,19 +1,188 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
     extract::State,
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
+use chaincash_predicate::{
+    context::{ContextProvider, NanoErg, NoteContext, PredicateContext},
+    predicates::{Accept, Predicate},
+};
 use chaincash_services::ServerState;
+use serde::Serialize;
 
 use crate::api::ApiError;
+
+#[derive(Default)]
+struct AcceptanceContextProvider {
+    issued_notes: HashMap<String, Vec<NoteContext>>,
+    reserves: HashMap<String, NanoErg>,
+}
+
+impl AcceptanceContextProvider {
+    fn from_state(state: &ServerState, note: NoteContext) -> Result<Self, ApiError> {
+        let mut issued_notes: HashMap<String, Vec<NoteContext>> = HashMap::new();
+        for stored_note in state.store.notes().note_contexts()? {
+            let stored_note = NoteContext {
+                nanoerg: stored_note.nanoerg,
+                owner: stored_note.owner,
+                issuer: stored_note.issuer,
+                signers: stored_note.signers,
+            };
+            issued_notes
+                .entry(stored_note.issuer.clone())
+                .or_default()
+                .push(stored_note);
+        }
+
+        issued_notes
+            .entry(note.issuer.clone())
+            .or_default()
+            .push(note);
+
+        Ok(Self {
+            issued_notes,
+            reserves: state.store.reserves().reserve_totals_by_owner()?,
+        })
+    }
+}
+
+impl ContextProvider for AcceptanceContextProvider {
+    fn agent_issued_notes(&self, agent: &str) -> Vec<NoteContext> {
+        self.issued_notes.get(agent).cloned().unwrap_or_default()
+    }
+
+    fn agent_reserves_nanoerg(&self, agent: &str) -> NanoErg {
+        self.reserves.get(agent).copied().unwrap_or_default()
+    }
+}
+
+#[derive(Serialize)]
+struct CheckNoteResponse {
+    accepted: bool,
+}
 
 async fn get_acceptance(State(state): State<Arc<ServerState>>) -> Result<Response, ApiError> {
     Ok(Json(&state.predicates).into_response())
 }
 
+fn predicates_accept_note(
+    predicates: &[Predicate],
+    note: NoteContext,
+    provider: AcceptanceContextProvider,
+) -> bool {
+    let context = PredicateContext { note, provider };
+
+    predicates
+        .iter()
+        .any(|predicate| predicate.accept(&context))
+}
+
+async fn check_note(
+    State(state): State<Arc<ServerState>>,
+    Json(note): Json<NoteContext>,
+) -> Result<Response, ApiError> {
+    let provider = AcceptanceContextProvider::from_state(&state, note.clone())?;
+    let accepted = predicates_accept_note(&state.predicates, note, provider);
+
+    Ok(Json(CheckNoteResponse { accepted }).into_response())
+}
+
 pub fn router() -> Router<Arc<ServerState>> {
-    Router::new().route("/", get(get_acceptance))
+    Router::new()
+        .route("/", get(get_acceptance))
+        .route("/checkNote", post(check_note))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use chaincash_store::{ChainCashStore, Update};
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    fn test_state(predicates: Vec<Predicate>) -> Arc<ServerState> {
+        let node = ergo_client::node::NodeClient::from_url_str(
+            "http://127.0.0.1:9052",
+            "hello".to_string(),
+            std::time::Duration::from_secs(5),
+        )
+        .unwrap();
+        let store = ChainCashStore::open_in_memory().unwrap();
+        store.update().unwrap();
+
+        Arc::new(ServerState::new(node, store, predicates))
+    }
+
+    fn note_json(owner: &str) -> Value {
+        json!({
+            "nanoerg": 1000,
+            "owner": owner,
+            "issuer": "issuer1",
+            "signers": ["issuer1"]
+        })
+    }
+
+    #[tokio::test]
+    async fn check_note_returns_true_when_predicate_accepts() {
+        let predicate = serde_json::from_value(json!({
+            "type": "whitelist",
+            "kind": "owner",
+            "agents": ["owner1"]
+        }))
+        .unwrap();
+
+        let response = router()
+            .with_state(test_state(vec![predicate]))
+            .oneshot(
+                Request::post("/checkNote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(note_json("owner1").to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({ "accepted": true })
+        );
+    }
+
+    #[tokio::test]
+    async fn check_note_returns_false_when_no_predicate_accepts() {
+        let predicate = serde_json::from_value(json!({
+            "type": "whitelist",
+            "kind": "owner",
+            "agents": ["owner1"]
+        }))
+        .unwrap();
+
+        let response = router()
+            .with_state(test_state(vec![predicate]))
+            .oneshot(
+                Request::post("/checkNote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(note_json("owner2").to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({ "accepted": false })
+        );
+    }
 }

--- a/crates/chaincash_store/src/notes.rs
+++ b/crates/chaincash_store/src/notes.rs
@@ -1,4 +1,4 @@
-use std::borrow::BorrowMut;
+use std::{borrow::BorrowMut, collections::HashMap};
 
 use chaincash_offchain::note_history::NoteHistory;
 use diesel::{
@@ -91,6 +91,13 @@ pub struct NoteWithHistory {
     #[serde(flatten)]
     pub note: Note,
     pub history: Vec<OwnershipEntry>,
+}
+
+pub struct StoredNoteContext {
+    pub nanoerg: u64,
+    pub owner: String,
+    pub issuer: String,
+    pub signers: Vec<String>,
 }
 
 pub struct NoteRepository {
@@ -186,6 +193,44 @@ impl NoteRepository {
             .into_iter()
             .zip(notes)
             .map(|(history, note)| NoteWithHistory { note, history })
+            .collect())
+    }
+
+    pub fn note_contexts(&self) -> Result<Vec<StoredNoteContext>, Error> {
+        let mut conn = self.pool.get()?;
+        let notes = schema::notes::table
+            .select(Note::as_select())
+            .load(conn.borrow_mut())?;
+        let reserve_owners: HashMap<String, String> = schema::reserves::table
+            .select((schema::reserves::identifier, schema::reserves::owner))
+            .load(conn.borrow_mut())?
+            .into_iter()
+            .collect();
+
+        Ok(OwnershipEntry::belonging_to(&notes)
+            .order_by(schema::ownership_entries::position.asc())
+            .select(OwnershipEntry::as_select())
+            .load(conn.borrow_mut())?
+            .grouped_by(&notes)
+            .into_iter()
+            .zip(notes)
+            .map(|(history, note)| {
+                let signers: Vec<String> = history
+                    .iter()
+                    .filter_map(|entry| reserve_owners.get(&entry.reserve_nft_id).cloned())
+                    .collect();
+                let issuer = signers
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| note.owner.clone());
+
+                StoredNoteContext {
+                    nanoerg: note.value.try_into().unwrap_or_default(),
+                    owner: note.owner,
+                    issuer,
+                    signers,
+                }
+            })
             .collect())
     }
 

--- a/crates/chaincash_store/src/reserves.rs
+++ b/crates/chaincash_store/src/reserves.rs
@@ -10,7 +10,7 @@ use ergo_lib::ergo_chain_types::EcPoint;
 use ergo_lib::ergotree_ir::chain;
 use ergo_lib::ergotree_ir::chain::ergo_box::BoxId;
 use ergo_lib::ergotree_ir::chain::token::TokenId;
-use std::borrow::BorrowMut;
+use std::{borrow::BorrowMut, collections::HashMap};
 
 #[derive(Queryable, Selectable, Associations)]
 #[diesel(belongs_to(ErgoBox, foreign_key = box_id))]
@@ -102,6 +102,25 @@ impl ReserveRepository {
             })
             .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()
             .expect("Failed to parse ReserveBoxSpec from database"))
+    }
+
+    pub fn reserve_totals_by_owner(&self) -> Result<HashMap<String, u64>, Error> {
+        let mut conn = self.pool.get()?;
+        let reserves = schema::reserves::table
+            .inner_join(schema::ergo_boxes::table)
+            .select((Reserve::as_select(), ErgoBox::as_select()))
+            .load::<(Reserve, ErgoBox)>(&mut conn)?;
+
+        let mut totals = HashMap::new();
+        for (reserve, ergo_box) in reserves {
+            let ergo_box = chain::ergo_box::ErgoBox::try_from(ergo_box)
+                .expect("Failed to parse ErgoBox from database");
+            let reserve_box = ReserveBoxSpec::try_from(&ergo_box)
+                .expect("Failed to parse ReserveBoxSpec from database");
+            *totals.entry(reserve.owner).or_default() += *reserve_box.ergo_box().value.as_u64();
+        }
+
+        Ok(totals)
     }
 
     /// Delete boxes that are not in latest scan (spent)


### PR DESCRIPTION
## Summary
Adds `POST /api/v1/acceptance/checkNote` so clients can submit a JSON encoded note and receive whether it is accepted by the configured predicates.

## Problem
Issue #51 requests an `/acceptance/checkNote` API method that accepts a JSON note via POST and returns whether that note can be accepted.

## Reproduction
Before this change, the acceptance router only exposed `GET /api/v1/acceptance/`, so a POST to `/api/v1/acceptance/checkNote` had no matching route.

With this PR, a client can call:

```sh
curl -X POST http://localhost:8080/api/v1/acceptance/checkNote \
  -H "content-type: application/json" \
  -d '{"nanoerg":1000,"owner":"owner1","issuer":"issuer1","signers":["issuer1"]}'
```

and receive:

```json
{"accepted":true}
```

when at least one configured predicate accepts the note.

## Root Cause
The predicate evaluation logic existed, but it was not exposed through an API route that accepted note context JSON.

## Fix
This PR:

- makes `NoteContext` serializable/deserializable for JSON API input
- adds a store-backed acceptance context provider for issued-note and reserve lookups
- adds `POST /api/v1/acceptance/checkNote`
- returns `{ "accepted": boolean }`
- adds API tests for accepted and rejected notes
- documents the new endpoint in the README

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p chaincash_server acceptance::tests -- --nocapture`
- `cargo test -p chaincash_server`
- `cargo test -p chaincash_store`
- `cargo test -p chaincash_predicate`
- `cargo test -p chaincash_server -p chaincash_store -p chaincash_predicate`

## Bounty
Intended to resolve BetterMoneyLabs/chaincash-rs#51, labeled `Bounty-1 gram of gold`.
